### PR TITLE
Typo in 02-fundamentals/lab/shell.md document, in the Shell variables section.

### DIFF
--- a/02-fundamentals/lab/shell.md
+++ b/02-fundamentals/lab/shell.md
@@ -71,7 +71,7 @@ which expands to `gcc -Wall arguments.c -o arguments`. If you want to use a vari
 
 It is good practice to double-quote variables used like this, because if you tried for example to compile a program called `silly name.c` with a space in its name, then
 
-    program="silly name"
+    program='silly name'
     gcc -Wall $program.c -o $program
 
 would expand to


### PR DESCRIPTION
I changed double quotes into single quotes in a example from the Shell variables section. Previously, the example incorrectly used double quotes when demonstrating the behaviour of a variable with spaces using single quotes,. I have corrected this mistake.
